### PR TITLE
Fix: Generate RSS feed item reverse order

### DIFF
--- a/scripts/gen-rss.js
+++ b/scripts/gen-rss.js
@@ -45,7 +45,7 @@ async function generate() {
   }))).flat()
 
   await Promise.all(
-    episodes.map(async (name) => {
+    episodes.reverse().map(async (name) => {
       if (name.startsWith('index.')) return
 
       const content = await fs.readFile(


### PR DESCRIPTION
RSS feed items should normally be in time descending order, but currently, it's in ascending order.